### PR TITLE
removed jQuery and added axios for ajax calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "axios": "^0.13.1",
     "immutable": "^3.8.1",
-    "jquery": "^3.1.0",
     "js-logger": "^1.3.0",
     "page": "^1.7.1",
     "react": "^0.14.7",

--- a/src/domain/middleware/network.js
+++ b/src/domain/middleware/network.js
@@ -17,7 +17,7 @@
 
 // @flow
 
-import $ from "jquery";
+import axios from "axios";
 
 import { getLogger } from "domain/logger";
 
@@ -29,24 +29,21 @@ const logger = getLogger("Middleware/network");
 
 // Make getUsers a importable function
 export function getUsers() {
-
-  // Define the postponable variable
-  const d = $.Deferred();
-
-  // Make the network call via ajax
-  $.getJSON("http://reqres.in/api/users?page=2").then( (response) => {
-    // Whenever it is ready, resolve the event and set its result
-    d.resolve(response.data.map( (datum) => {
-      return {
-        firstName: datum.first_name,
-        lastName: datum.last_name
-      };
-    } ));
-
-  });
-
-  // Return the promise of a response
-  return d.promise();
+  // Make the network call via ajax using axios
+  return axios.get("http://reqres.in/api/users?page=2")
+      // Whenever it is ready, it will resolve the event and set its result
+       .then(response => {
+         return response.data.data.map( (datum) => {
+           return {
+             firstName: datum.first_name,
+             lastName: datum.last_name
+           };
+         });
+       })
+       // Or it will throw an error
+      .catch( err => {
+        console.error(err);
+      });
 }
 
 // Make onUsersFromNetwork a importable function


### PR DESCRIPTION
Axios is a promise based HTTP client. ( https://github.com/mzabriskie/axios )
Embracing node philosophy and leveraging the npm ecosystem, axios feels more suitable than using the whole jquery for ajax calls.Plus axios is super tiny , with good documentation and active development.